### PR TITLE
Add separate templating functions for strings vs files

### DIFF
--- a/src/clj/spire/namespaces.clj
+++ b/src/clj/spire/namespaces.clj
@@ -117,6 +117,8 @@
         (quote ~'sudo) (sci-bind-macro sudo/sudo ~ns-sym)
 
         (quote ~'selmer) (copy-var selmer/selmer ~ns-sym)
+        (quote ~'render-string) (copy-var selmer/render-string ~ns-sym)
+        (quote ~'render-file) (copy-var selmer/render-file ~ns-sym)
 
         (quote ~'download*) (copy-var download/download* ~ns-sym)
         (quote ~'download) (sci-bind-macro download/download ~ns-sym)

--- a/src/clj/spire/selmer.clj
+++ b/src/clj/spire/selmer.clj
@@ -10,3 +10,28 @@
                      source
                      (slurp (io/input-stream (io/file cwd source))))]
     (parser/render pre-markup vars)))
+
+(defn render-string
+  "Render a string template to a string.
+  Accepts the same arguments as `selmer.parser/render`"
+  [s context-map & [opts]]
+  (parser/render s context-map opts))
+
+(defn render-file
+  "Render a template in a file to a string.
+  `file-path` is the relative path to the file to render.
+  `context-map` and `opts` are the same as those expected by `selmer.parser/render`"
+  [file-path context-map & [opts]]
+  (let [cwd (utils/current-file-parent)
+        pre-markup (slurp (io/input-stream (io/file cwd file-path)))]
+    (parser/render pre-markup context-map opts)))
+
+(comment
+  (selmer "foo {{ bar }}" {:bar "qux"} :data)
+  ;; paths are relative to spire repo in dev
+  (selmer  "local/test-template" {:bar "qux"})
+
+  (render-string "foo {{ bar }}" {:bar "qux"})
+  (render-file "local/test-template" {:bar "qux"})
+
+  (render-string "foo [{ bar }]" {:bar "baz"} {:tag-open \[ :tag-close \]}))


### PR DESCRIPTION
I wanted to add support for `selmer.parser/render`'s optional final `opts` argument, but it would have been clunky to add to the existing `selmer` function, since that use an optional third argument for flags. However, the only flag is one called `:data`, that determines whether we're reading a file or just using a given string. I think a simpler api is to just have two functions: one for strings and one for files. This PR has that, and each new function supports `selmer.parser/render`'s 3rd argument.

IMO `spire.selmer/selmer` should be deprecated in favor of the new functions.

I left my "rich comment" in there, happy to remove if you prefer.