### PR TITLE
Upgrade SCI + babashka.nrepl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/core.async "0.6.532"]
                  [org.clojure/tools.cli "0.4.2"]
-                 [org.babashka/sci "0.2.8"]
+                 [org.babashka/sci "0.3.2"]
 
-                 [babashka/babashka.nrepl "0.0.3"]
+                 [babashka/babashka.nrepl "0.0.6"]
                  [fipp "0.6.23"]
                  [mvxcvi/puget "1.2.0"]
                  [digest "1.4.9"]


### PR DESCRIPTION
Babashka nREPL still pulled in `borkdude/sci`.

SCI has moved to a new organization: `org.babashka/sci {:mvn/version "0.3.2"}`.

Having both `borkdude/sci` and `org.babashka/sci` on the classpath can cause problems.